### PR TITLE
chore(domain): support running it remotely

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,13 @@ The official Docker installation page can be found [here](https://docs.docker.co
 If you are using Linux, then the official Docker installation does not come with Docker Compose. The official Docker Compose installation page can be found [here](https://docs.docker.com/compose/install/#prerequisites). You can also read an overview of what Docker Compose is [here](https://docs.docker.com/compose/overview/) if you want some extra background information. Go through the steps of installing Docker Compose for your platform, then proceed to setting up credentials.
 
 ### Setting up Credentials
-Setup the credentials with the provided script by running:
+Setup credentials for fence, self-signed CA  and SSL cert with the provided script by running:
 ```
 bash creds_setup.sh
 ```
-This script will create `temp_creds` and `temp_keys` directories with the credential files in it. 
+This script will create `temp_creds` and `temp_keys` directories with the credential files in it.
+The script by default generate SSL cert for `localhost`, if you are running this in a remote server with an actual domain, you can run `bash creds_setup.sh YOUR_DOMAIN`. This will create SSL cert using the self-signed CA that we will mount to the containers. If you have real certs for your domain, you can copy to `temp_creds/service.key` and `temp_creds/service.crt` to overwrite our dev certs.
+
 
 If you are using MacOS, you may run into an error with the default MacOS OpenSSL config not including the configuration for v3_ca certificate generation. You can refer to the solution on [this Github issue](https://github.com/jetstack/cert-manager/issues/279) on a related issue on Jetstack's cert-manager.
 

--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ The official Docker installation page can be found [here](https://docs.docker.co
 If you are using Linux, then the official Docker installation does not come with Docker Compose. The official Docker Compose installation page can be found [here](https://docs.docker.com/compose/install/#prerequisites). You can also read an overview of what Docker Compose is [here](https://docs.docker.com/compose/overview/) if you want some extra background information. Go through the steps of installing Docker Compose for your platform, then proceed to setting up credentials.
 
 ### Setting up Credentials
-Setup credentials for fence, self-signed CA  and SSL cert with the provided script by running:
+Setup credentials for fence, a custom root CA  and SSL certs with the provided script by running:
 ```
 bash creds_setup.sh
 ```
 This script will create `temp_creds` and `temp_keys` directories with the credential files in it.
-The script by default generate SSL cert for `localhost`, if you are running this in a remote server with an actual domain, you can run `bash creds_setup.sh YOUR_DOMAIN`. This will create SSL cert using the self-signed CA that we will mount to the containers. If you have real certs for your domain, you can copy to `temp_creds/service.key` and `temp_creds/service.crt` to overwrite our dev certs.
+The script by default generate SSL cert for `localhost`, if you are running this in a remote server with an actual domain, you can run `bash creds_setup.sh YOUR_DOMAIN`. This will create SSL cert signed by the custom CA so that the microservices can talk to each other without bypassing SSL verification. You will still need to bypass SSL verification when you hit the services from the browser. If you have real certs for your domain, you can copy to `temp_creds/service.key` and `temp_creds/service.crt` to overwrite our dev certs.
 
 
 If you are using MacOS, you may run into an error with the default MacOS OpenSSL config not including the configuration for v3_ca certificate generation. You can refer to the solution on [this Github issue](https://github.com/jetstack/cert-manager/issues/279) on a related issue on Jetstack's cert-manager.

--- a/creds_setup.sh
+++ b/creds_setup.sh
@@ -15,7 +15,8 @@ openssl rsa -pubout -in temp_keys/${timestamp}/jwt_private_key.pem \
 
 
 # generate certs for nginx ssl
-SUBJ="/countryName=US/stateOrProvinceName=IL/localityName=Chicago/organizationName=CDIS/organizationalUnitName=PlanX/commonName=localhost/emailAddress=cdis@uchicago.edu"
+commonName=${1:-localhost}
+SUBJ="/countryName=US/stateOrProvinceName=IL/localityName=Chicago/organizationName=CDIS/organizationalUnitName=PlanX/commonName=$commonName/emailAddress=cdis@uchicago.edu"
 openssl req -new -x509 -nodes -extensions v3_ca -keyout temp_creds/ca-key.pem \
     -out temp_creds/ca.pem -days 365 -subj $SUBJ
 if [[ $? -eq 1 ]]; then    

--- a/scripts/sheepdog_setup.sh
+++ b/scripts/sheepdog_setup.sh
@@ -9,5 +9,7 @@ done
 
 echo "postgres is ready"
 
+update-ca-certificates
+
 python /sheepdog/bin/setup_transactionlogs.py --host postgres --user sheepdog_user --password sheepdog_pass --database metadata_db
 bash /sheepdog/dockerrun.bash


### PR DESCRIPTION
support 
`bash creds_setup.sh CUSTOM_DOMAIN` to generate certs for real domain, this is not signed using any real CA though. But the dev CA is mounted to the containers so it can pass verification for microservices' communication. The browser will still need to add exception for uncertified cert