### PR TITLE
modified docker-compose to set a different entry point and setup scri…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,8 @@ services:
       - postgres
   peregrine:
     image: "quay.io/cdis/peregrine:master"
-    command: bash /peregrine_setup.sh
+    entrypoint: /bin/bash
+    command: /peregrine_setup.sh
     networks:
       - devnet
     volumes:


### PR DESCRIPTION
I was unable to run the docker-compose stack due to errors with peregrine. It looks like the entry point on existing container isn't compatible with peregrin_setup.sh, so I re-set entry point to /bin/bash. Also peregrine_setup.sh references the dockerrun file by the wrong name so I fixed that.