### PR TITLE
Docs/docker compose commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Docker-compose setup for experimental commons, small commons, or local developme
 
 
 ## Introduction
-This setup uses Docker containers for postgres, indexd, fence, peregrine, sheepdog, data-portal and nginx. Images for the cdis microservices and nginx will be pulled from quay.io (master), while postgres (9.5) images will be pulled from Docker Hub. Nginx will be used as a reverse proxy to each of the services. Config file formats were copied from [cloud-automation](https://github.com/uc-cdis/cloud-automation) and stored in the `Secrets` directory and modified for local use with Docker Compose. Setup scripts for some of the containers are kept in the `scripts` directory.
+This setup uses Docker containers for postgres, indexd, fence, peregrine, sheepdog, data-portal and nginx. Images for the cdis microservices and nginx will be pulled from quay.io (master), while postgres (9.5) images will be pulled from Docker Hub. Nginx will be used as a reverse proxy to each of the services. Below you will find information about [migrating existing](#Release-History-and-Migration-Instructions) and [setting up](#Setup) new compose services, some [tips](#Dev-Tips) and basic information about [using](#Using-the-data-commons) data commons. You can quickly find commonly used commands in our [cheat sheet](./docs/cheat_sheet.md). Config file formats were copied from [cloud-automation](https://github.com/uc-cdis/cloud-automation) and stored in the `Secrets` directory and modified for local use with Docker Compose. Setup scripts for some of the containers are kept in the `scripts` directory.
 
 ### Release History and Migration Instructions
 
@@ -136,6 +136,8 @@ docker logs -f portal-service
 ```
 
 ## Dev Tips
+
+You can quickly find commonly used commands for compose services in our [cheat sheet](./docs/cheat_sheet.md).
 
 When developing, you can have local repositories of the services you are working on and use volumes to mount your local repository files onto the containers to override the containers' code (which is built from GitHub using quay.io). Then, you can restart a single container with
 ```

--- a/docs/cheat_sheet.md
+++ b/docs/cheat_sheet.md
@@ -47,7 +47,7 @@ Update in docker-compose.yml:
   * ndh (Niaid)
   * va
 
-**Use local code**
+**Use local code (example with fence)**
 
 Update in docker-compose.yml:
 ```
@@ -55,6 +55,6 @@ fence-service:
     image: "my-fence:latest"
 ```
 Rerun the following commands after changing the code:
-* docker build . -t my-fence -f Dockerfile ()
+* cd fence; docker build . -t my-fence -f Dockerfile
 * docker stop fence-service
 * docker-compose up -d fence-service


### PR DESCRIPTION
- add link to the cheat sheet in the readme
- fix "use local code" section of the cheat sheet