### PR TITLE
fix DICTIONARY_URL and PATH_TO_SCHEMA_DIR

### DIFF
--- a/templates/peregrine_settings.py
+++ b/templates/peregrine_settings.py
@@ -31,7 +31,10 @@ config['HMAC_ENCRYPTION_KEY'] = conf_data.get( 'hmac_key', '{{hmac_key}}' )
 config['FLASK_SECRET_KEY'] = conf_data.get( 'gdcapi_secret_key', '{{gdcapi_secret_key}}' )
 config['PSQL_USER_DB_CONNECTION'] = 'postgresql://%s:%s@%s:5432/%s' % tuple([ conf_data.get(key, key) for key in ['fence_username', 'fence_password', 'fence_host', 'fence_database']])
 
-config['DICTIONARY_URL'] = environ.get('DICTIONARY_URL','https://s3.amazonaws.com/dictionary-artifacts/datadictionary/develop/schema.json')
+if environ.get('DICTIONARY_URL'):
+    config['DICTIONARY_URL'] = environ.get('DICTIONARY_URL')
+else:
+    config['PATH_TO_SCHEMA_DIR'] = environ.get('PATH_TO_SCHEMA_DIR')
 
 config['SUBMISSION'] = {
     'bucket': conf_data.get( 'bagit_bucket', '{{bagit_bucket}}' )

--- a/templates/sheepdog_settings.py
+++ b/templates/sheepdog_settings.py
@@ -53,7 +53,11 @@ config['USER_API'] = 'http://fence-service/'
 # token when redirecting, used during local docker compose setup when the
 # services are on different containers but the hostname is still localhost
 config['FORCE_ISSUER'] = True
-config['DICTIONARY_URL'] = environ.get('DICTIONARY_URL','https://s3.amazonaws.com/dictionary-artifacts/datadictionary/develop/schema.json')
+
+if environ.get('DICTIONARY_URL'):
+    config['DICTIONARY_URL'] = environ.get('DICTIONARY_URL')
+else:
+    config['PATH_TO_SCHEMA_DIR'] = environ.get('PATH_TO_SCHEMA_DIR')
 
 app_init(app)
 application = app


### PR DESCRIPTION
Revert sheepdog/peregrine to prefer DICTIONARY_URL but still alternate to PATH_TO_SCHEMA_DIR if former is absent