### PR TITLE
remove double quotes from arborist-service environment definition

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
     networks:
       - devnet
     environment:
-      - JWKS_ENDPOINT="http://fence-service/.well-known/jwks"
+      - JWKS_ENDPOINT=http://fence-service/.well-known/jwks
     depends_on:
       - fence-service
   peregrine-service:


### PR DESCRIPTION
when attempting to upload a file with the `gen3-client`, the following error appears:
```
arborist-service     | 2019/04/12 18:49:55 /go/src/github.com/uc-cdis/arborist/arborist/server/logging.go:34: INFO: error decoding token: [parse "http://fence-service/.well-known/jwks": first path segment in URL cannot contain colon]
```
this error is resolved by removing double quotes in the entry for `environment` in docker-compose.yml's `arborist-service` section:
```
JWKS_ENDPOINT="http://fence-service/.well-known/jwks"
```
changed to
```
JWKS_ENDPOINT=http://fence-service/.well-known/jwks
```
pleases arborist and allows the upload to succeed:
```
arborist-service     | 192.168.240.6 - - [12/Apr/2019:18:56:14 +0000] "POST /auth/request HTTP/1.1" 200 14 "" "python-requests/2.21.0"
```