### PR TITLE
fix 502 large token error

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -53,6 +53,21 @@ http {
         # proxy_set_header   X-UserId "$userid";
 
         #
+        # Accomodate large jwt token headers
+        # * http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffer_size
+        # * https://ma.ttias.be/nginx-proxy-upstream-sent-big-header-reading-response-header-upstream/
+        #
+        proxy_buffer_size          16k;
+        proxy_buffers              8 16k;
+        proxy_busy_buffers_size    32k;
+        #
+        # also incoming from client:
+        # * https://fullvalence.com/2016/07/05/cookie-size-in-nginx/
+        # * https://nginx.org/en/docs/http/ngx_http_core_module.html#client_header_buffer_size
+        large_client_header_buffers 4 8k;
+        client_header_buffer_size 4k;
+
+        #
         # CSRF check
         # This block requires a csrftoken for all POST requests.
         #


### PR DESCRIPTION
### Bug Fixes

Resolves the 502 Bad Gateway error from nginx.

revproxy-service     | 2019/05/15 18:01:59 [error] 6#6: *36 upstream sent too big header while reading response header from upstream, client: 172.19.0.1, server: revproxy-service, request: "GET 